### PR TITLE
Adding code coverage for Maven and Gradle projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.idea/
+
+*.iml
+target/

--- a/azure-pipelines.Gradle.yml
+++ b/azure-pipelines.Gradle.yml
@@ -17,7 +17,7 @@ steps:
     jdkArchitectureOption: 'x64'
     publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'
-    tasks: 'build jacocoTestReport'
+    tasks: 'build'
 
 # Publish Cobertura or JaCoCo code coverage results from a build
 - task: PublishCodeCoverageResults@1

--- a/azure-pipelines.Gradle.yml
+++ b/azure-pipelines.Gradle.yml
@@ -17,8 +17,16 @@ steps:
     jdkArchitectureOption: 'x64'
     publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'
-    tasks: 'build'
+    tasks: 'build jacocoTestReport'
 
+# Publish Cobertura or JaCoCo code coverage results from a build
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: 'JaCoCo' 
+    summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/reports/code-cov-report.xml'
+    reportDirectory: '$(System.DefaultWorkingDirectory)/**/reports/code-cov-report.html'
+    failIfCoverageEmpty: true
+    
 - task: CopyFiles@2
   inputs:
     contents: '**/helloworld*.jar'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,15 @@ steps:
     testResultsFiles: '**/TEST-*.xml'
     goals: 'package'
 
+# Publish Code Coverage Results
+# Publish Cobertura or JaCoCo code coverage results from a build
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: 'JaCoCo' # Options: cobertura, jaCoCo
+    summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/site/jacoco/jacoco.xml'
+    reportDirectory: '$(System.DefaultWorkingDirectory)/**/site/jacoco' # Optional
+    failIfCoverageEmpty: true # Optional
+
 - task: CopyFiles@2
   inputs:
     contents: '**/*.war'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,14 +18,13 @@ steps:
     testResultsFiles: '**/TEST-*.xml'
     goals: 'package'
 
-# Publish Code Coverage Results
 # Publish Cobertura or JaCoCo code coverage results from a build
 - task: PublishCodeCoverageResults@1
   inputs:
-    codeCoverageTool: 'JaCoCo' # Options: cobertura, jaCoCo
+    codeCoverageTool: 'JaCoCo' 
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/site/jacoco/jacoco.xml'
-    reportDirectory: '$(System.DefaultWorkingDirectory)/**/site/jacoco' # Optional
-    failIfCoverageEmpty: true # Optional
+    reportDirectory: '$(System.DefaultWorkingDirectory)/**/site/jacoco'
+    failIfCoverageEmpty: true
 
 - task: CopyFiles@2
   inputs:

--- a/build.gradle
+++ b/build.gradle
@@ -25,5 +25,3 @@ jacocoTestReport {
         html.enabled true
         html.destination "${buildDir}/reports/code-cov-report.html"
 }
-
-check.dependsOn jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,21 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version:'4.11'
 }
 
-jacocoTestReport {
+task codeCoverageReport(type: JacocoReport) {
+    executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+
+    subprojects.each {
+        sourceSets it.sourceSets.main
+    }
+
     reports {
         xml.enabled true
+        xml.destination "${buildDir}/reports/jacoco/report.xml"
         html.enabled false
+        csv.enabled false
     }
 }
 
-check.dependsOn jacocoTestReport
+codeCoverageReport.dependsOn {
+    subprojects*.test
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'jacoco'
 
 group = 'helloworld'
 version = '1.0-SNAPSHOT'
@@ -16,3 +17,12 @@ repositories {
 dependencies {
     testCompile group: 'junit', name: 'junit', version:'4.11'
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled false
+    }
+}
+
+check.dependsOn jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -24,4 +24,7 @@ jacocoTestReport {
         xml.destination "${buildDir}/reports/code-cov-report.xml"
         html.enabled true
         html.destination "${buildDir}/reports/code-cov-report.html"
+    }
 }
+
+check.dependsOn jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -18,21 +18,12 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version:'4.11'
 }
 
-task codeCoverageReport(type: JacocoReport) {
-    executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
-
-    subprojects.each {
-        sourceSets it.sourceSets.main
-    }
-
+jacocoTestReport {
     reports {
         xml.enabled true
         xml.destination "${buildDir}/reports/code-cov-report.xml"
         html.enabled true
         html.destination "${buildDir}/reports/code-cov-report.html"
-    }
 }
 
-codeCoverageReport.dependsOn {
-    subprojects*.test
-}
+check.dependsOn jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,9 @@ task codeCoverageReport(type: JacocoReport) {
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/report.xml"
-        html.enabled false
-        csv.enabled false
+        xml.destination "${buildDir}/reports/code-cov-report.xml"
+        html.enabled true
+        html.destination "${buildDir}/reports/code-cov-report.html"
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
 						</goals>
 						<configuration>
 							<!-- Sets the path to the file which contains the execution data. -->
-
 							<dataFile>target/jacoco.exec</dataFile>
 							<!-- Sets the output directory for the code coverage report. -->
 							<outputDirectory>target/jacoco-ut</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,48 @@
 
   <build>
     <finalName>helloworld</finalName>
+
+    <plugins>
+      <plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.2</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-unit-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+
+							<dataFile>target/jacoco.exec</dataFile>
+							<!-- Sets the output directory for the code coverage report. -->
+							<outputDirectory>target/jacoco-ut</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<systemPropertyVariables>
+						<jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+    </plugins>
   </build>
 
   <properties>

--- a/src/main/java/com/microsoft/demo/Demo.java
+++ b/src/main/java/com/microsoft/demo/Demo.java
@@ -1,0 +1,12 @@
+package com.microsoft.demo;
+
+public class Demo {
+    public void DoSomething(boolean flag){
+        if(flag){
+            System.out.println("I am covered");
+            return;
+        }
+
+        System.out.println("I am not covered");
+    }
+}

--- a/src/test/java/MyTest.java
+++ b/src/test/java/MyTest.java
@@ -1,8 +1,11 @@
-import org.junit.*;
+import com.microsoft.demo.Demo;
+import org.junit.Test;
 
 public class MyTest {
     @Test
     public void test_method_1() {
+        Demo d = new Demo();
+        d.DoSomething(true);
     }
 
     @Test


### PR DESCRIPTION
This is to address issue #2 

This will add code cov using Jacoco to the project for both maven and gradle.
For this,

- The source code was changed to integrate the tests with conditionals in the code

- the build.gradle for Gradle was updated to add the Jacoco plugin configurations

- the pom.xml for Maven was updated to add the Jacoco plugin configurations

- the pipeline yaml for both Gradle and Maven were updated to add the Publish Code cov task