### PR TITLE
Commenting out jar in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 .mtj.tmp/
 
 # Package Files #
-*.jar
+#*.jar
 *.war
 *.nar
 *.ear


### PR DESCRIPTION
Commenting out the jar reference in Gitignore so that Gradle can successfully build. 